### PR TITLE
Remove an unused library import

### DIFF
--- a/src/app/core/core.module.ts
+++ b/src/app/core/core.module.ts
@@ -1,6 +1,5 @@
 import { NgModule } from '@angular/core';
 import { HttpClientModule } from '@angular/common/http';
-import { FlexLayoutModule } from '@angular/flex-layout';
 
 @NgModule({
   imports: [


### PR DESCRIPTION
Library FlexLayout was being imported but not used. It's not a compatible library and will throw an error when attempting to start the server.